### PR TITLE
Fixed desync issue with darkmode slider

### DIFF
--- a/app/static/js/theme.js
+++ b/app/static/js/theme.js
@@ -1,0 +1,16 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const checkbox = document.querySelector("input[data-toggle-theme]");
+  const storedTheme = localStorage.getItem("theme");
+
+  if (checkbox && storedTheme) {
+    const [light, dark] = checkbox.dataset.toggleTheme.split(",");
+    checkbox.checked = storedTheme === dark;
+  }
+
+  // Set a default theme if none exists
+  if (!storedTheme) {
+    const defaultTheme = "garden";
+    localStorage.setItem("theme", defaultTheme);
+    document.documentElement.setAttribute("data-theme", defaultTheme);
+  }
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="garden">
+<html lang="en">
   <head>
     <title>🍅 Plant Monitor</title> {# TODO CONVERT THIS TO DYNAMIC CONTENT#}
     <meta name="description" content="The best plant watering app ever!">
@@ -20,8 +20,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
           rel="stylesheet">
-    {# <link rel="stylesheet"
-       href="{{ url_for('static', filename='css/main.css') }}"> #}
     {% block head %}
     {% endblock head %}
   </head>


### PR DESCRIPTION
BUG: Dark mode slider would always default to the left (light mode) the local storage could have dark mode stored, and whilst the slider would still alternate the dark/light modes it would be out of sync. 

FIX: Added a check on what is stored in local storage and set the slider to the matching position on page load. 

RESULT:
![image](https://github.com/user-attachments/assets/89ff7f62-359d-4bb7-be31-7f0f2246497f)
