### PR TITLE
Fixed logic with testing import into create app

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -31,7 +31,10 @@ def request_loader(request):
 def create_app(test_config=None):
     app = Flask(__name__)
 
-    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///plant_info.db"
+    if test_config is not None:
+        app.config.update(test_config)
+    else:
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///plant_info.db"
 
     # used user management. (sessions / messages etc.) now being created after the app is initalised.
     app.secret_key = secrets.token_hex(32)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -31,7 +31,7 @@ def request_loader(request):
 def create_app(test_config=None):
     app = Flask(__name__)
 
-    if test_config is not None:
+    if test_config:
         app.config.update(test_config)
     else:
         app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///plant_info.db"

--- a/tests/unit/test_database_config.py
+++ b/tests/unit/test_database_config.py
@@ -1,0 +1,5 @@
+def test_abc(client, db_session):
+    db_location = db_session.get_bind().url
+    print(db_location)
+
+    assert "memory" in str(db_location)

--- a/tests/unit/test_home.py
+++ b/tests/unit/test_home.py
@@ -56,13 +56,10 @@ def test_show_homepage(client, db_session):
     row = RawData(timestamp=10000, value=33)
     db_session.add(row)
 
-    db_location = db_session.get_bind().url
-
     db_session.commit()
 
     response = client.get("/")
 
-    assert "memory" in str(db_location)
     assert response.status_code == 200
     assert b"Moisture levels critical" in response.data
     assert b"33" in response.data

--- a/tests/unit/test_home.py
+++ b/tests/unit/test_home.py
@@ -56,10 +56,13 @@ def test_show_homepage(client, db_session):
     row = RawData(timestamp=10000, value=33)
     db_session.add(row)
 
+    db_location = db_session.get_bind().url
+
     db_session.commit()
 
     response = client.get("/")
 
+    assert "memory" in str(db_location)
     assert response.status_code == 200
     assert b"Moisture levels critical" in response.data
     assert b"33" in response.data


### PR DESCRIPTION
BUG: Home tests were hitting real database. 

FIX: Added testing  conditional into create app that uses the config if it's passed in.